### PR TITLE
Support for unicode word breaks

### DIFF
--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -1,5 +1,5 @@
 
-const WORD_BOUNDARY_PATTERN = /\W/;
+var WORD_BOUNDARY_PATTERN = /[^-'’\p{Letter}\p{Number}]/u; /* includes both kinds of apostrophes */
 
 function indexOfWordBoundary(target: string, startIndex: number): number {
   const n = target.length;


### PR DESCRIPTION
Migrated to using a Unicode-aware expression for word breaks. It also allows for embedded apostrophes (2 types) and hyphens in words.